### PR TITLE
Fix typo: perform preventive validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Forms are so important in the world of HTML, CSS and Javascript that I decided t
 
 2. How to use dropdowns.
 
-3. How to form preventive validations.
+3. 3. How to perform preventive validations.
 
 4. The difference between GET and POST.
 


### PR DESCRIPTION
Se reemplazó 'form preventive validations' por 'perform preventive validations' para mejorar la gramática del texto.